### PR TITLE
Detect all train stops, including from mods

### DIFF
--- a/tnp/stop.lua
+++ b/tnp/stop.lua
@@ -67,7 +67,7 @@ function tnp_stop_getall(player)
     local tnp_stops = {}
 
     local entities = player.surface.find_entities_filtered({
-        name = "train-stop"
+        type = "train-stop"
     })
     for _, ent in pairs(entities) do
         if tnp_stop_check(ent) then


### PR DESCRIPTION
Update the search for all train stops to include anything with type `train-stop`, so that stops added by other mods such as LTN, TSM, and any other mod, are also discovered.