### PR TITLE
Add support for pressing Enter in the search box to go to the first entry

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -37,6 +37,7 @@ script.on_event(defines.events.on_player_dropped_item, tnp_handle_player_dropped
 script.on_event(defines.events.on_gui_checked_state_changed, tnp_handle_gui_check)
 script.on_event(defines.events.on_gui_click, tnp_handle_gui_click)
 script.on_event(defines.events.on_gui_text_changed, tnp_handle_gui_text)
+script.on_event(defines.events.on_gui_confirmed, tnp_handle_gui_confirmed)
 
 -- Shortcut Events
 script.on_event(defines.events.on_lua_shortcut, tnp_handle_shortcut)

--- a/tnp/event.lua
+++ b/tnp/event.lua
@@ -46,6 +46,20 @@ function tnp_handle_gui_text(event)
     end
 end
 
+-- tnp_handle_gui_confirmed()
+--   Handles a gui confirm
+function tnp_handle_gui_confirmed(event)
+    local player = game.players[event.player_index]
+
+    if not player.valid then
+        return
+    end
+
+    if event.element.name == "tnp-stationlist-search" then
+        tnp_gui_stationlist_search_confirm(player, event.element)
+    end
+end
+
 -- tnp_handle_input()
 --   Handles a request via the custom input
 function tnp_handle_input(event)

--- a/tnp/gui.lua
+++ b/tnp/gui.lua
@@ -342,6 +342,29 @@ function tnp_gui_stationlist_search(player, element)
     end
 end
 
+function tnp_gui_stationlist_search_confirm(player, element)
+    element = element or tnp_state_player_get(player, 'gui_stationsearch')
+
+    if not element or not element.valid then
+        return
+    end
+
+    local gui_stationsearch_area = element.parent
+    local gui_top = gui_stationsearch_area.parent
+
+    for _, stationlist in pairs(gui_top.children) do
+        if stationlist.name:sub(1, 27) == "tnp-stationlist-stationlist" then
+            local stationtable = stationlist.children[1]
+            for _, row in pairs(stationtable.children) do
+                if row and row.valid and row.visible then
+                    local station = row.children[1]
+                    return tnp_action_stationselect_redispatch(player, station)
+                end
+            end
+        end
+    end
+end
+
 -- tnp_gui_stationlist_switch()
 --   Switches the type of stationlist shown
 function tnp_gui_stationlist_switch(player, element)


### PR DESCRIPTION
If there are any rows visible, pressing enter in the search field will act like clicking on the first one. Just a nice time saver.