### PR TITLE
Bugfix: timeout_arrival feature

### DIFF
--- a/tnp/state_train.lua
+++ b/tnp/state_train.lua
@@ -152,7 +152,7 @@ function tnp_state_train_timeout()
     for id, data in pairs(global.train_data) do
         -- Exclude any trains pending a prune, or without a timeout
         if data.train.valid then
-            if data.timeout_arrival and data.timeout_arrival >= 0 then
+            if data.timeout_arrival and data.timeout_arrival > 0 then
                 data.timeout_arrival = data.timeout_arrival - 1
                 if data.timeout_arrival <= 0 then
                     table.insert(trains.arrival, data.train)


### PR DESCRIPTION
Fixed issue - if timeout_arrival is zero, logic with activating

---
Hello author, I found this bug using your mod - if I set timeout_arrival  in cfg - arrival logic always activating - then I request a train.
